### PR TITLE
Debian Jessie based Vagrant box

### DIFF
--- a/{{cookiecutter.repo_name}}/Vagrantfile
+++ b/{{cookiecutter.repo_name}}/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "torchbox/wagtail"
+  config.vm.box = "torchbox/wagtail-jessie64"
   config.vm.box_version = "~> 1.0"
 
   # Disable automatic box update checking. If you disable this, then

--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,9 +1,9 @@
 Django==1.8.4
-psycopg2==2.6
+psycopg2==2.6.1
 elasticsearch==1.2.0
 django-redis==3.8.2
 celery==3.1.17
 wagtail==1.1rc1
 django-libsass==0.3
-libsass==0.8.2
-Pillow==2.8.1
+libsass==0.8.3
+Pillow==2.9.0

--- a/{{cookiecutter.repo_name}}/vagrant/provision.sh
+++ b/{{cookiecutter.repo_name}}/vagrant/provision.sh
@@ -14,9 +14,9 @@ su - vagrant -c "createdb $PROJECT_NAME"
 
 
 # Virtualenv setup for project
-su - vagrant -c "pyvenv $VIRTUALENV_DIR"
+su - vagrant -c "virtualenv --python=python3 $VIRTUALENV_DIR"
 # Replace previous line with this if you are using Python 2
-# su - vagrant -c "/usr/local/bin/virtualenv $VIRTUALENV_DIR"
+# su - vagrant -c "virtualenv --python=python2 $VIRTUALENV_DIR"
 
 su - vagrant -c "echo $PROJECT_DIR > $VIRTUALENV_DIR/.project"
 


### PR DESCRIPTION
There's a new Debian jessie based vagrant box here: https://github.com/torchbox/vagrant-wagtail-base/tree/jessie

This has some advantages over the Ubuntu based current box:
 - More up to date packages
  - PostgreSQL 9.4
  - Python 2.7.9/3.4.2 now installed with APT (instead of manually built)
  - Fabric/sphinx installed with APT too
 - Elasticsearch 1.7.1
 - pip 7 (with wheel cache prefilled with psycopg2, libsass and pillow for much faster setup)