### PR TITLE
Logging improvements

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -12,3 +12,4 @@ Pillow==2.9.0
 dj-database-url==0.3.0
 whitenoise==2.0.4
 uwsgi==2.0.11.2
+ConcurrentLogHandler==0.9.1

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
@@ -150,6 +150,12 @@ LOGGING = {
         }
     },
     'loggers': {
+        '{{ cookiecutter.repo_name }}': {
+            'handlers':     [],
+            'level':        'INFO',
+            'propagate':    False,
+            'formatter':    'verbose',
+        },
         'wagtail': {
             'handlers':     [],
             'level':        'INFO',
@@ -173,6 +179,16 @@ LOGGING = {
 
 
 if 'LOG_DIR' in env:
+    # {{ cookiecutter.project_name }} log
+    LOGGING['handlers']['{{ cookiecutter.repo_name }}_file'] = {
+        'level':        'INFO',
+        'class':        'cloghandler.ConcurrentRotatingFileHandler',
+        'filename':     os.path.join(env['LOG_DIR'], '{{ cookiecutter.repo_name }}.log'),
+        'maxBytes':     5242880, # 5MB
+        'backupCount':  5
+    }
+    LOGGING['loggers']['wagtail']['handlers'].append('{{ cookiecutter.repo_name }}_file')
+
     # Wagtail log
     LOGGING['handlers']['wagtail_file'] = {
         'level':        'INFO',

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
@@ -163,7 +163,7 @@ LOGGING = {
 if 'ERROR_LOG' in env:
     LOGGING['handlers']['errors_file'] = {
         'level':        'ERROR',
-        'class':        'logging.handlers.RotatingFileHandler',
+        'class':        'cloghandler.ConcurrentRotatingFileHandler',
         'filename':     env['ERROR_LOG'],
         'maxBytes':     5242880, # 5MB
         'backupCount':  5

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
@@ -150,6 +150,12 @@ LOGGING = {
         }
     },
     'loggers': {
+        'wagtail': {
+            'handlers':     [],
+            'level':        'INFO',
+            'propagate':    False,
+            'formatter':    'verbose',
+        },
         'django.request': {
             'handlers':     ['mail_admins'],
             'level':        'ERROR',
@@ -167,6 +173,16 @@ LOGGING = {
 
 
 if 'LOG_DIR' in env:
+    # Wagtail log
+    LOGGING['handlers']['wagtail_file'] = {
+        'level':        'INFO',
+        'class':        'cloghandler.ConcurrentRotatingFileHandler',
+        'filename':     os.path.join(env['LOG_DIR'], 'wagtail.log'),
+        'maxBytes':     5242880, # 5MB
+        'backupCount':  5
+    }
+    LOGGING['loggers']['wagtail']['handlers'].append('wagtail_file')
+
     # Error log
     LOGGING['handlers']['errors_file'] = {
         'level':        'ERROR',

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
@@ -159,12 +159,12 @@ LOGGING = {
 }
 
 
-# Log errors to file
-if 'ERROR_LOG' in env:
+if 'LOG_DIR' in env:
+    # Error log
     LOGGING['handlers']['errors_file'] = {
         'level':        'ERROR',
         'class':        'cloghandler.ConcurrentRotatingFileHandler',
-        'filename':     env['ERROR_LOG'],
+        'filename':     os.path.join(env['LOG_DIR'], 'error.log'),
         'maxBytes':     5242880, # 5MB
         'backupCount':  5
     }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/settings/production.py
@@ -144,16 +144,23 @@ LOGGING = {
             'class': 'django.utils.log.AdminEmailHandler',
         },
     },
+    'formatters': {
+        'default': {
+            'verbose': '[%(asctime)s] (%(process)d/%(thread)d) %(name)s %(levelname)s: %(message)s'
+        }
+    },
     'loggers': {
         'django.request': {
             'handlers':     ['mail_admins'],
             'level':        'ERROR',
             'propagate':    False,
+            'formatter':    'verbose',
         },
         'django.security': {
             'handlers':     ['mail_admins'],
             'level':        'ERROR',
             'propagate':    False,
+            'formatter':    'verbose',
         },
     },
 }


### PR DESCRIPTION
This makes some improvements to logging
 - Fixes a bug where multiple processes may rotate the log at the same time, causing logs to be lost
 - Use ``LOG_DIR`` instead of ``ERROR_LOG`` environment variable
 - Made the log format more verbose. Now includes time, process/thread ids and level
 - Writes all INFO, WARNING, ERROR and CRITICAL logs from Wagtail and the project to a file

Currently untested